### PR TITLE
Add gallery screen navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,4 +63,6 @@ dependencies {
     implementation("androidx.camera:camera-extensions:1.3.2")
     implementation("androidx.compose.material:material-icons-core:1.5.0")
     implementation("androidx.compose.material:material-icons-extended:1.5.0")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("io.coil-kt:coil-compose:2.6.0")
 }

--- a/app/src/main/java/com/shabeer/camerax/MainActivity.kt
+++ b/app/src/main/java/com/shabeer/camerax/MainActivity.kt
@@ -23,11 +23,14 @@ import androidx.camera.video.*
 import androidx.camera.video.FileOutputOptions
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,7 +42,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavController
 import com.google.common.util.concurrent.ListenableFuture
+import com.shabeer.camerax.ui.GalleryScreen
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
@@ -54,9 +62,13 @@ class MainActivity : ComponentActivity() {
         cameraExecutor = Executors.newSingleThreadExecutor()
 
         setContent {
+            val navController = rememberNavController()
             MaterialTheme(colorScheme = darkColorScheme()) {
                 Surface(modifier = Modifier.fillMaxSize()) {
-                    CameraApp(cameraExecutor)
+                    NavHost(navController = navController, startDestination = "camera") {
+                        composable("camera") { CameraApp(cameraExecutor, navController) }
+                        composable("gallery") { GalleryScreen(navController) }
+                    }
                 }
             }
         }
@@ -80,7 +92,7 @@ fun createFile(context: Context, extension: String): File {
 }
 
 @Composable
-fun CameraApp(cameraExecutor: ExecutorService) {
+fun CameraApp(cameraExecutor: ExecutorService, navController: NavController) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
@@ -150,13 +162,28 @@ fun CameraApp(cameraExecutor: ExecutorService) {
         Text("Smart Camera", fontSize = 22.sp, fontWeight = FontWeight.Bold, color = Color.White)
         Spacer(modifier = Modifier.height(8.dp))
 
-        AndroidView(
-            factory = { previewView },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(400.dp)
-                .background(Color.DarkGray, shape = RoundedCornerShape(12.dp))
-        )
+        Box(modifier = Modifier
+            .fillMaxWidth()
+            .height(400.dp)) {
+            AndroidView(
+                factory = { previewView },
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.DarkGray, shape = RoundedCornerShape(12.dp))
+            )
+            IconButton(
+                onClick = { navController.navigate("gallery") },
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.PhotoLibrary,
+                    contentDescription = "Gallery",
+                    tint = Color.White
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(12.dp))
 

--- a/app/src/main/java/com/shabeer/camerax/ui/GalleryScreen.kt
+++ b/app/src/main/java/com/shabeer/camerax/ui/GalleryScreen.kt
@@ -1,0 +1,126 @@
+package com.shabeer.camerax.ui
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Environment
+import android.widget.VideoView
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import java.io.File
+
+@Composable
+fun GalleryScreen(navController: NavController) {
+    val context = LocalContext.current
+    var hasPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        hasPermission = granted
+    }
+    LaunchedEffect(Unit) {
+        if (!hasPermission) {
+            launcher.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+    }
+    val mediaDir = remember {
+        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)
+            .resolve("SmartCameraX")
+    }
+    var selectedFile by remember { mutableStateOf<File?>(null) }
+    val files = remember(hasPermission) {
+        if (hasPermission) mediaDir.listFiles()?.sortedByDescending { it.lastModified() }
+            ?: emptyArray() else emptyArray()
+    }
+    Box(Modifier.fillMaxSize().background(Color.Black)) {
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(128.dp),
+            modifier = Modifier.fillMaxSize()
+        ) {
+            items(files) { file ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(4.dp).clickable { selectedFile = file }
+                ) {
+                    if (file.extension.lowercase() in listOf("jpg", "jpeg", "png")) {
+                        AsyncImage(
+                            model = file,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(120.dp)
+                                .background(Color.DarkGray, RoundedCornerShape(8.dp))
+                        )
+                    } else {
+                        Box(
+                            Modifier
+                                .size(120.dp)
+                                .background(Color.DarkGray, RoundedCornerShape(8.dp)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(Icons.Default.Videocam, contentDescription = null, tint = Color.White)
+                        }
+                    }
+                    Text(file.name, color = Color.White, fontSize = 12.sp)
+                }
+            }
+        }
+        IconButton(onClick = { navController.navigateUp() }, modifier = Modifier.align(Alignment.TopStart)) {
+            Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
+        }
+        selectedFile?.let { file ->
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black)
+                    .clickable { selectedFile = null },
+                contentAlignment = Alignment.Center
+            ) {
+                if (file.extension.lowercase() in listOf("jpg", "jpeg", "png")) {
+                    AsyncImage(model = file, contentDescription = null, modifier = Modifier.fillMaxSize())
+                } else {
+                    AndroidView(factory = {
+                        VideoView(it).apply {
+                            setVideoURI(Uri.fromFile(file))
+                            setOnPreparedListener { mp ->
+                                mp.isLooping = true
+                                start()
+                            }
+                        }
+                    }, modifier = Modifier.fillMaxSize())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add navigation and coil dependencies
- build a GalleryScreen composable to view saved media
- integrate NavController in `MainActivity`
- overlay gallery icon on camera preview

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852940ae98c8332a09901aa485c1f51