### PR TITLE
Add gallery screen navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,4 +63,6 @@ dependencies {
     implementation("androidx.camera:camera-extensions:1.3.2")
     implementation("androidx.compose.material:material-icons-core:1.5.0")
     implementation("androidx.compose.material:material-icons-extended:1.5.0")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("io.coil-kt:coil-compose:2.6.0")
 }

--- a/app/src/main/java/com/shabeer/camerax/MainActivity.kt
+++ b/app/src/main/java/com/shabeer/camerax/MainActivity.kt
@@ -20,18 +20,22 @@ import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.*
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.video.*
-import androidx.camera.video.FileOutputOptions
+import androidx.camera.video.MediaStoreOutputOptions
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import android.os.Environment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
@@ -39,7 +43,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavController
 import com.google.common.util.concurrent.ListenableFuture
+import com.shabeer.camerax.ui.GalleryScreen
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
@@ -54,9 +63,13 @@ class MainActivity : ComponentActivity() {
         cameraExecutor = Executors.newSingleThreadExecutor()
 
         setContent {
+            val navController = rememberNavController()
             MaterialTheme(colorScheme = darkColorScheme()) {
                 Surface(modifier = Modifier.fillMaxSize()) {
-                    CameraApp(cameraExecutor)
+                    NavHost(navController = navController, startDestination = "camera") {
+                        composable("camera") { CameraApp(cameraExecutor, navController) }
+                        composable("gallery") { GalleryScreen(navController) }
+                    }
                 }
             }
         }
@@ -75,12 +88,14 @@ enum class Mode {
 fun createFile(context: Context, extension: String): File {
     val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
     val fileName = "CAMERA_${timeStamp}.$extension"
-    val outputDir = context.cacheDir
+    val outputDir =
+        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM)
+            .resolve("SmartCameraX").apply { mkdirs() }
     return File(outputDir, fileName)
 }
 
 @Composable
-fun CameraApp(cameraExecutor: ExecutorService) {
+fun CameraApp(cameraExecutor: ExecutorService, navController: NavController) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
@@ -150,13 +165,28 @@ fun CameraApp(cameraExecutor: ExecutorService) {
         Text("Smart Camera", fontSize = 22.sp, fontWeight = FontWeight.Bold, color = Color.White)
         Spacer(modifier = Modifier.height(8.dp))
 
-        AndroidView(
-            factory = { previewView },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(400.dp)
-                .background(Color.DarkGray, shape = RoundedCornerShape(12.dp))
-        )
+        Box(modifier = Modifier
+            .fillMaxWidth()
+            .height(400.dp)) {
+            AndroidView(
+                factory = { previewView },
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.DarkGray, shape = RoundedCornerShape(12.dp))
+            )
+            IconButton(
+                onClick = { navController.navigate("gallery") },
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.PhotoLibrary,
+                    contentDescription = "Gallery",
+                    tint = Color.White
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(12.dp))
 
@@ -289,8 +319,15 @@ fun CameraApp(cameraExecutor: ExecutorService) {
                 } else {
                     videoCapture?.let { capture ->
                         if (!isRecording) {
-                            val videoFile = createFile(context, "mp4")
-                            val mediaStoreOutput = FileOutputOptions.Builder(videoFile).build()
+                            val contentValues = android.content.ContentValues().apply {
+                                put(android.provider.MediaStore.MediaColumns.DISPLAY_NAME, "VID_${'$'}{System.currentTimeMillis()}")
+                                put(android.provider.MediaStore.MediaColumns.MIME_TYPE, "video/mp4")
+                                put(android.provider.MediaStore.MediaColumns.RELATIVE_PATH, "DCIM/SmartCameraX")
+                            }
+                            val mediaStoreOutput = MediaStoreOutputOptions.Builder(
+                                context.contentResolver,
+                                android.provider.MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+                            ).setContentValues(contentValues).build()
                             recording = capture.output.prepareRecording(context, mediaStoreOutput)
                                 .start(ContextCompat.getMainExecutor(context)) {
                                     when (it) {

--- a/app/src/main/java/com/shabeer/camerax/ui/GalleryScreen.kt
+++ b/app/src/main/java/com/shabeer/camerax/ui/GalleryScreen.kt
@@ -1,0 +1,179 @@
+package com.shabeer.camerax.ui
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.MediaStore
+import android.content.ContentUris
+import android.widget.VideoView
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import android.content.Context
+
+data class GalleryItem(val uri: Uri, val name: String, val isVideo: Boolean)
+
+private fun loadMedia(context: Context): List<GalleryItem> {
+    val items = mutableListOf<GalleryItem>()
+    val projection = arrayOf(
+        MediaStore.MediaColumns._ID,
+        MediaStore.MediaColumns.DISPLAY_NAME
+    )
+    val selection = "${MediaStore.MediaColumns.RELATIVE_PATH}=?"
+    val selectionArgs = arrayOf("DCIM/SmartCameraX/")
+    val sortOrder = "${MediaStore.MediaColumns.DATE_MODIFIED} DESC"
+
+    context.contentResolver.query(
+        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+        projection,
+        selection,
+        selectionArgs,
+        sortOrder
+    )?.use { cursor ->
+        val idCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
+        val nameCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+        while (cursor.moveToNext()) {
+            val id = cursor.getLong(idCol)
+            val name = cursor.getString(nameCol)
+            val uri = ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id)
+            items.add(GalleryItem(uri, name, false))
+        }
+    }
+
+    context.contentResolver.query(
+        MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
+        projection,
+        selection,
+        selectionArgs,
+        sortOrder
+    )?.use { cursor ->
+        val idCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID)
+        val nameCol = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+        while (cursor.moveToNext()) {
+            val id = cursor.getLong(idCol)
+            val name = cursor.getString(nameCol)
+            val uri = ContentUris.withAppendedId(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, id)
+            items.add(GalleryItem(uri, name, true))
+        }
+    }
+
+    return items
+}
+
+@Composable
+fun GalleryScreen(navController: NavController) {
+    val context = LocalContext.current
+    val requiredPermissions = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+        arrayOf(Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO)
+    } else {
+        arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+    }
+
+    var hasPermission by remember {
+        mutableStateOf(requiredPermissions.all {
+            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+        })
+    }
+
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { result ->
+        hasPermission = result.all { it.value }
+    }
+
+    LaunchedEffect(Unit) {
+        if (!hasPermission) {
+            launcher.launch(requiredPermissions)
+        }
+    }
+
+    var selectedItem by remember { mutableStateOf<GalleryItem?>(null) }
+    val items = remember(hasPermission) { if (hasPermission) loadMedia(context) else emptyList() }
+
+    Box(Modifier.fillMaxSize().background(Color.Black)) {
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(128.dp),
+            modifier = Modifier.fillMaxSize()
+        ) {
+            items(items) { item ->
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .clickable { selectedItem = item }
+                ) {
+                    if (!item.isVideo) {
+                        AsyncImage(
+                            model = item.uri,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(120.dp)
+                                .background(Color.DarkGray, RoundedCornerShape(8.dp))
+                        )
+                    } else {
+                        Box(
+                            Modifier
+                                .size(120.dp)
+                                .background(Color.DarkGray, RoundedCornerShape(8.dp)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(Icons.Default.Videocam, contentDescription = null, tint = Color.White)
+                        }
+                    }
+                    Text(item.name, color = Color.White, fontSize = 12.sp)
+                }
+            }
+        }
+
+        IconButton(onClick = { navController.navigateUp() }, modifier = Modifier.align(Alignment.TopStart)) {
+            Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
+        }
+
+        selectedItem?.let { item ->
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black)
+                    .clickable { selectedItem = null },
+                contentAlignment = Alignment.Center
+            ) {
+                if (!item.isVideo) {
+                    AsyncImage(model = item.uri, contentDescription = null, modifier = Modifier.fillMaxSize())
+                } else {
+                    AndroidView(factory = {
+                        VideoView(it).apply {
+                            setVideoURI(item.uri)
+                            setOnPreparedListener { mp ->
+                                mp.isLooping = true
+                                start()
+                            }
+                        }
+                    }, modifier = Modifier.fillMaxSize())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add navigation and coil dependencies
- build a GalleryScreen composable to view saved media
- integrate NavController in `MainActivity`
- overlay gallery icon on camera preview
- save videos via MediaStore and load gallery items through MediaStore queries

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852940ae98c8332a09901aa485c1f51